### PR TITLE
v2.1.2 - Documentation alignment and missing command definition

### DIFF
--- a/.agent/focus/solutions.md
+++ b/.agent/focus/solutions.md
@@ -1,7 +1,7 @@
 ## Purpose
 Research and present multiple viable approaches with objective pros/cons analysis incorporating stakeholder perspectives.
 
-## Gaol
+## Goal
 - Design solutions
 
 ## Research Area

--- a/.agent/roles/README.md
+++ b/.agent/roles/README.md
@@ -1,6 +1,6 @@
 # Stakeholder Roles
 
-This directory contains role definitions used by SAID commands (like `/analyze-options` and `/analyze-risks`) to provide domain-specific perspectives and expertise.
+This directory contains role definitions used by SAID commands (like `/analyze` ) to provide domain-specific perspectives and expertise.
 
 ## Adding New Roles
 
@@ -17,7 +17,7 @@ Each role file must contain two main sections:
 
 **Identity**: Brief description of the role's professional identity and experience level
 
-**Expertise**: 
+**Expertise**:
 - List of specific technical or domain expertise areas
 - Skills and knowledge domains
 - Areas of specialization
@@ -64,5 +64,5 @@ Roles can be used in two ways:
 
 Example:
 ```
-/analyze-options "Mobile app with Node.js backend" --roles=mobile-native-client-architect,service-architect
+/analyze "Mobile app with Node.js backend" --roles=mobile-native-client-architect,service-architect
 ```

--- a/.agent/templates/project-context-init.md
+++ b/.agent/templates/project-context-init.md
@@ -28,17 +28,17 @@ This is the main project context file that provides vision and architecture over
 ```yaml
 technology_decisions:
   - decision_area: "Backend Framework"
-    selected_option: "[To be determined through /analyze-options]"
+    selected_option: "[To be determined through /analyze solutions]"
     rationale: "[Why this was chosen]"
     alternatives_considered: ["[Option 1]", "[Option 2]"]
-    
+
   - decision_area: "Database"
-    selected_option: "[To be determined through /analyze-options]"
+    selected_option: "[To be determined through /analyze solutions]"
     rationale: "[Why this was chosen]"
     alternatives_considered: ["[Option 1]", "[Option 2]"]
-    
+
   - decision_area: "Frontend Framework"
-    selected_option: "[To be determined through /analyze-options]"
+    selected_option: "[To be determined through /analyze solutions]"
     rationale: "[Why this was chosen]"
     alternatives_considered: ["[Option 1]", "[Option 2]"]
 ```

--- a/.claude/commands/prime-context.md
+++ b/.claude/commands/prime-context.md
@@ -1,0 +1,93 @@
+## Usage
+```
+/prime-context
+```
+
+## Required Patterns
+Load: `.agent/patterns/sync/context-files.md` (context file management)
+
+## Purpose
+Update CLAUDE.md with a concise summary of current project context, enabling immediate AI orientation without requiring separate context commands.
+
+## Main Role
+You are a context curator specializing in AI session priming. Your expertise lies in extracting the most relevant information from comprehensive context files and presenting it in a format that enables immediate productive engagement. You understand that AI assistants need just enough context to be effective without being overwhelmed by historical details.
+
+## Process
+
+### 1. Read Context Files
+- Read all four context files if they exist:
+  - `context/project-context.md` - Main context manifest
+  - `context/project/decisions-made.md` - Key decisions with rationale
+  - `context/project/open-questions.md` - Unresolved questions
+  - `context/project/lessons-learned.md` - Insights and patterns
+- Handle missing files gracefully
+
+### 2. Extract Key Information
+- **From project-context.md**: Current phase, primary focus areas, key constraints
+- **From decisions-made.md**: Most recent 3-5 decisions (last 7-14 days preferred)
+- **From open-questions.md**: Top 2-3 critical unresolved questions
+- **From lessons-learned.md**: Most relevant insights for current work
+
+### 3. Generate Context Summary
+Create a concise summary optimized for AI orientation:
+- Current development phase and status
+- Recent important decisions that affect ongoing work
+- Active work areas or TODOs
+- Critical constraints or blockers to remember
+- Key technical choices already made
+
+### 4. Update CLAUDE.md
+- Locate the marked section in CLAUDE.md (between BEGIN/END PRIME-CONTEXT markers)
+- Replace entire marked section with new summary
+- Preserve all content outside the markers
+- Include update timestamp
+
+## Context Summary Template
+```markdown
+<!-- BEGIN PRIME-CONTEXT -->
+<!-- This section is automatically updated by /prime-context command -->
+<!-- Last updated: YYYY-MM-DD HH:MM:SS -->
+
+### Current Project State
+
+**Development Phase**: [Current phase from project-context.md]
+**Primary Focus**: [Main work areas or objectives]
+
+**Recent Key Decisions** (last 7 days):
+- [Decision 1 with brief rationale]
+- [Decision 2 with brief rationale]
+- [Decision 3 with brief rationale]
+
+**Active Constraints**:
+- [Critical constraint 1]
+- [Critical constraint 2]
+
+**Critical Open Questions**:
+- [Top priority unresolved question]
+- [Second priority question if critical]
+
+**Technical Stack Choices**:
+- [Key technology decision 1]
+- [Key technology decision 2]
+
+<!-- END PRIME-CONTEXT -->
+```
+
+## Quality Standards
+- Summary must be under 30 lines to maintain CLAUDE.md readability
+- Focus on actionable, current information over historical context
+- Include only decisions/info that directly impacts ongoing work
+- Use bullet points for quick scanning
+- Timestamp for context freshness awareness
+
+## Error Handling
+- If no context files exist, create minimal placeholder with initialization reminder
+- If CLAUDE.md lacks markers, append marked section after "Important Notes"
+- If context files are malformed, extract what's possible and note issues
+- Never delete content outside the marked section
+
+## Integration Notes
+- This command complements, not replaces, detailed context commands
+- Run after significant context updates or at start of new work sessions
+- Safe for version control - clear separation of static/dynamic content
+- Designed for "context priming" after breaks in development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,144 +10,68 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Purpose
 
-This is a **meta-template repository** for establishing AI-human collaboration patterns in software development. It provides the **Spiral AI Development (SAID)** methodology - a systematic approach to managing complex projects with AI assistance.
+This is a meta-template repository for the **Spiral AI Development (SAID)** methodology - a systematic approach for managing complex projects through AI-human collaboration. It provides commands and patterns for progressive understanding and implementation.
 
-## Core Framework
+## Existing SAID Commands
 
-**Spiral AI Development (SAID)** uses task-focused workflows achieving progressive detail levels:
-- **Level 0**: Vision clarity through `/analyze-problem` and `/analyze-risks`
-- **Level 1**: Approach viability through `/analyze-options` and `/sync-decision`
-- **Level 2+**: Progressive decomposition using `/decompose` with type definitions:
-  - Project-level: `/decompose .agent/layers/project.md`
-  - Component-level: `/decompose .agent/layers/component.md`
-  - Feature-level: `/decompose .agent/layers/feature.md`
-  - TODO execution: `/decompose .agent/layers/todo.md` → `/work-on-todo`
+All commands are located in `.claude/commands/`:
 
-## Available Commands
+### /analyze `<focus>` `<input-description>` `[--roles=<role1,role2,...>]`
+Universal analysis command that performs focused research and analysis. Available focus types (from `.agent/focus/`):
+- `problems` - Problem identification and clarification
+- `risks` - Risk assessment and mitigation strategies
+- `solutions` - Solution options with trade-offs
 
-### Analysis Commands
-- `/analyze-problem` - Validate and clarify problem understanding
-- `/analyze-options` - Present solution options with trade-offs
-- `/analyze-risks` - Identify and analyze project risks
+### /sync-context `<any-file>` or `init`
+Extracts and integrates critical information from any file into project context files. Use `init` to initialize context structure from templates.
 
-### Context Management Commands
-- `/sync-decision` - Integrate decisions into context with rationale
-- `/sync-context` - Maintain context across phases and prevent information loss
+### /sync-decision `<context-file>` `<decision-report>` `<selected-option>`
+Formally integrates a selected decision from an analysis report into the project's decision history with full traceability.
 
-### Decomposition Commands
-- `/decompose` - Universal decomposition using type definitions (project/component/feature/todo)
+### /prime-context
+Updates the CLAUDE.md file with a concise summary of current project state from context files, enabling quick AI orientation.
 
-### Planning Commands
-- `/plan-next-steps` - Create detailed transition plans with resource estimates
+### /decompose `<type-definition-file>` `<context-file>`
+Executes type-specific decomposition using definitions from `.agent/layers/`:
+- `project.md` - High-level project breakdown
+- `component.md` - System component analysis
+- `feature.md` - Feature-level decomposition
+- `todo.md` - Atomic task decomposition
 
-### TODO Workflow Commands
-- `/create-todo` - Create contexts for newly discovered TODOs
-- `/create-todo-from-report` - Extract TODOs from analysis reports
-- `/work-on-todo` - Execute atomic TODOs with collaboration checkpoints
+### /plan-next-steps `<current-phase>` `[context-file]`
+Generates detailed transition plans with prioritized actions and resource estimates.
 
-## Key Collaboration Principles
+### /create-todo `<todo-description>`
+Transforms a TODO description into structured context suitable for SAID integration.
 
-1. **Context Preservation**: Maintain structured context using three-file system
-   - `context/project-context.md` - Main context manifest with current state
-   - `context/project/decisions-made.md` - Key decisions with rationale and traceability
-   - `context/project/open-questions.md` - Unresolved questions requiring multi-phased analysis
-   - `context/project/lessons-learned.md` - Insights and patterns discovered
-   - Context templates in `.agent/templates/` for initialization
-   - Type definitions in `.agent/layers/` for decomposition guidance
+### /create-todo-from-report `<report-file>`
+Extracts actionable items from analysis reports and creates TODO contexts.
 
-2. **Bounded Replaceability**: Design components with clear interfaces that can be understood and replaced without archaeological investigation
+### /work-on-todo `<todo-context-file>` `[--expert=<expert-name>]`
+Executes atomic TODO items with collaboration checkpoints. Expert systems available in `.agent/experts/`.
 
-3. **Git-Hook Testing Integration**: Define testing automation strategies early to prevent massive failures
-   - Level 2: Component testing boundaries and responsibilities
-   - Level 3: Comprehensive git-hook testing strategy (primary integration point)
-   - Level 4: Git-hook implementation and team onboarding
-   - See `docs/SAID/add-ons/git-hook-testing-integration.md` for detailed guidance
+## Key Directories
 
-## Directory Structure
+- `.claude/commands/` - SAID command definitions
+- `.agent/` - Framework support files:
+  - `focus/` - Analysis focus definitions (problems, risks, solutions)
+  - `layers/` - Decomposition type definitions
+  - `roles/` - Stakeholder role definitions for analysis
+  - `experts/` - Domain expert systems for implementation
+  - `patterns/` - Reusable pattern files
+  - `templates/` - Context initialization templates
+- `docs/reports/` - Generated analysis reports
+- `context/` - Project context files (created by SAID)
 
-**Meta-template structure** (this repository):
-```
-/
-├── .claude/                     # SAID framework files for claude
-│   ├── commands/                # 10 SAID development commands
-├── .agent/                     # SAID framework files for agents
-│   ├── decompose-types/         # Decomposition type definitions
-│   │   ├── project.md           # Project decomposition type
-│   │   ├── component.md         # Component decomposition type
-│   │   ├── feature.md           # Feature decomposition type
-│   │   └── todo.md              # TODO decomposition type
-│   ├── patterns/                # 20 reusable pattern files
-│   │   ├── analyze/             # Analysis command patterns
-│   │   ├── general/             # Shared patterns (checkpoints, core)
-│   │   ├── plan/                # Planning patterns
-│   │   ├── sync/                # Context synchronization patterns
-│   │   └── todo/                # TODO workflow patterns
-│   ├── roles/                   # Role definitions for stakeholder analysis
-│   └── templates/               # Context initialization templates
-│       └── project-init/        # Project initialization templates
-├── docs/
-│   ├── reports/                 # Phase reports and analysis (Markdown)
-│   └── SAID/                    # SAID methodology documentation
-└── README.md                    # Project overview
-```
+## Working with SAID
 
-**Project structure** (when using SAID):
-```
-/
-├── context/                     # Context preservation files (created by SAID)
-│   ├── project-context.md       # Main context manifest
-│   └── project/                 # Project-specific context files
-│       ├── decisions-made.md    # Key decisions with rationale
-│       ├── open-questions.md    # Unresolved questions
-│       └── lessons-learned.md   # Insights and patterns
-├── docs/
-│   ├── design/                  # Project-specific design documents
-│   │   ├── OVERVIEW.md          # Project elevator pitch
-│   │   └── HIGH-LEVEL-DESIGN.md # Core principles and requirements
-│   └── reports/                 # Phase reports and analysis
-├── .claude/                     # SAID framework for claude (copied from meta-template)
-├── .agent/                     # SAID framework for agents (copied from meta-template)
-└── [project files]              # Actual project implementation
-```
+1. **Starting a Project**: Create design documents then run `/sync-context init`
+2. **Analysis Phase**: Use `/analyze` with appropriate focus
+3. **Decision Making**: Use `/sync-decision` to record choices
+4. **Decomposition**: Use `/decompose` progressively from project to TODO level
+5. **Implementation**: Use `/work-on-todo` for atomic task execution
+6. **Context Management**: Use `/prime-context` to restore context between sessions
 
-## Common Workflow Patterns
+## Development Notes
 
-**Level 0 (Vision Clarity)**:
-```bash
-/analyze-problem
-/analyze-risks
-/sync-context
-```
-
-**Level 1 (Approach Viability)**:
-```bash
-/analyze-options
-/sync-decision
-/sync-context
-```
-
-**Level 2+ (Progressive Decomposition)**:
-```bash
-/decompose .agent/layers/project.md [parent-context]
-/decompose .agent/layers/component.md [parent-context]
-/decompose .agent/layers/feature.md [parent-context]
-```
-
-**Context Recovery** (when context is lost):
-```bash
-/sync-context [source-file]
-/plan-next-steps
-```
-
-**Starting New Project**:
-1. Create `docs/design/OVERVIEW.md` and `docs/design/HIGH-LEVEL-DESIGN.md`
-2. Run `/sync-context init`
-3. Begin with `/analyze-problem` to establish clear problem understanding
-
-## Important Notes
-
-- This is a methodology template, not implementation code
-- Always question before acting on major decisions
-- Present options with pros/cons rather than choosing for the user
-- Maintain context integrity across all phase transitions
-- Framework provides escape valves for timeline pressure situations
+This is a methodology template repository - there are no traditional build, test, or lint commands. The focus is on the SAID commands and workflows for managing AI-human collaboration in software projects.

--- a/README.md
+++ b/README.md
@@ -4,28 +4,37 @@
 [![GitHub Template](https://img.shields.io/badge/GitHub-Template-6e5494.svg)](https://github.com/rjroy/claude-code-template/generate)
 [![Claude Code](https://img.shields.io/badge/AI_Partner-Claude_Code-D97757.svg)](https://claude.ai/code)
 
-[![Template Version](https://img.shields.io/badge/Version-v2.1.1-blue.svg)](https://github.com/rjroy/claude-code-template)
+[![Template Version](https://img.shields.io/badge/Version-v2.1.2-blue.svg)](https://github.com/rjroy/claude-code-template)
 [![Maintained](https://img.shields.io/badge/Maintained-Yes-brightgreen.svg)](https://github.com/rjroy/claude-code-template/commits/main)
 [![SAID](https://img.shields.io/badge/Methodology-SAID-16A34A.svg)](docs/SAID/philosophy)
 
 
-A meta-template for establishing AI-human collaboration patterns in software development, designed for managing complex projects with Claude Code.
+A meta-template for establishing AI-human collaboration patterns in software development. SAID addresses the collaboration paradox: AI excels at quick solutions for well-understood domains, but complex problems require progressive understanding to avoid incomplete solutions that miss critical constraints.
 
 ## Core Framework
 
 <img src="docs/SAID/logos/said-64.png" align="right" style="margin-left: 10px">
 
-**Spiral AI Development (SAID)** - A methodology for AI-human collaboration that breaks complex problems into progressive detail levels, from high-level vision to working implementation.
+**Spiral AI Development (SAID)** - A methodology for AI-human collaboration that navigates uncertainty through progressive certainty. Rather than linear phases, SAID uses thresholds of understanding to make decisions only when you have sufficient information.
 
-**Philosophy** - AI excels at generating quick small solutions for well understood domains. The current AI collaboration loop therefore relies on the user breaking the problem down and clearly defining it before starting. If you don't then you get a quick small solution for a complex problem, which doesn't work as you expect. Spiral AI Development addresses this by adapting proven development principles to AI collaboration. The framework provides both a spiral methodology and command tools to navigate it consistently.
+**The Collaboration Paradox** - AI provides fluent, complete-looking solutions that often miss critical constraints. This creates false confidence - solutions that "look right" but fail when tested against reality. SAID addresses this through iterative deepening: identifying and resolving nuances before implementation, not after.
 
 ## Key Components
 
-- **Context Building** - The greatest power and enemy of AI is its context. Working on a complex problem can be difficult if it loses context. You need to build it up, and preserve it.
-- **Domain Breakdown** - One of the problems is knowing where to draw the lines between components and features. It is also one of the most important action you can do when working with AI.
-- **Spiral Methodology** - The traditional spiral development model can be adapted to most modern agile development processes. As you progress through the methodology it is important to add new context for future levels of the spiral. But more important adjust past assumptions that are now wrong and recalibrate.
-- **Human in the Loop** - This methodology isn't a push button solution. It is designed to take advantage of the greatest domain expert the AI has access to, the user. This is your project, it needs to ask you questions.
-- **Command Driven** - This is all great in theory, but in practice you need more than just words to maintain consistency. Spiral AI Development isn't just a philosophy, it is a toolkit template. It provides a baseline set of commands to support all the core concepts (and some optional ones) to allow for consistency in the development for multiple projects.
+- **Context as Navigation Aid** - Context files are maps through the spiral, not just documentation. SAID addresses four context problems: poisoning (errors repeated), distraction (overwhelm), confusion (too many options), and clash (contradictions).
+
+- **Progressive Detail Levels** - Make decisions only at appropriate thresholds:
+  - **Level 0**: Problem + Risk Clarity
+  - **Level 1**: Approach Viability
+  - **Level 2**: Structure Definition
+  - **Level 3**: Implementation Specifics
+  - **Level 4**: Working Implementation
+
+- **Ownership Architecture** - Clear boundaries between human judgment (strategy, trade-offs), AI assistance (research, implementation), and shared territory (review, testing).
+
+- **High-Performing Intern Pattern** - Commands behave like skilled interns: adaptive checkpoints over rigid templates, bounded initiative, context-aware depth, and efficient question bundling.
+
+- **Bounded Replaceability** - Design components so any piece can be understood and replaced without archaeological investigation. The Investigation-Decision-Integration pattern provides the natural workflow rhythm.
 
 ## Getting Started
 
@@ -42,8 +51,10 @@ Please follow the [Getting Started](/docs/SAID/getting-started/README.md) comple
 
 - Philosophy: [Core Concepts](/docs/SAID/philosophy/core-concepts.md)
 - Philosophy: [Implementation Guide](/docs/SAID/philosophy/implementation-guide.md)
+- Philosophy: [Command Design Principles](/docs/SAID/philosophy/command-design-principles.md)
 - Philosophy: [Version](/docs/SAID/philosophy/version.md)
 - Getting Started: [README](/docs/SAID/getting-started/README.md)
+- Getting Started: [How-To](/docs/SAID/getting-started/HOW-TO.md)
 - Add Ons: [Context Priming Pattern](/docs/SAID/add-ons/context-priming-pattern.md)
-- Add Ons: [Todo Workflow Integration](/docs/SAID/add-ons/todo-workflow-integration.md)
+- Add Ons: [Git Hook Testing](/docs/SAID/add-ons/git-hook-testing-integration.md)
 

--- a/docs/SAID/getting-started/HOW-TO.md
+++ b/docs/SAID/getting-started/HOW-TO.md
@@ -1,0 +1,308 @@
+# SAID Commands HOW-TO Guide
+
+This guide provides practical usage instructions for all Spiral AI Development (SAID) commands. Each command entry includes syntax, arguments, purpose, usage timing, and examples.
+
+## Table of Contents
+
+- [Analysis Commands](#analysis-commands)
+  - [/analyze](#analyze)
+- [Context Management Commands](#context-management-commands)
+  - [/sync-context](#sync-context)
+  - [/sync-decision](#sync-decision)
+  - [/prime-context](#prime-context)
+- [Decomposition Commands](#decomposition-commands)
+  - [/decompose](#decompose)
+- [Planning Commands](#planning-commands)
+  - [/plan-next-steps](#plan-next-steps)
+- [TODO Workflow Commands](#todo-workflow-commands)
+  - [/create-todo](#create-todo)
+  - [/create-todo-from-report](#create-todo-from-report)
+  - [/work-on-todo](#work-on-todo)
+
+---
+
+## Analysis Commands
+
+### /analyze
+
+**Command**: `/analyze <focus> <input-description> [--roles=<role1,role2,...>]`
+
+**Arguments**:
+- `<focus>`: Type of analysis to perform
+  - Available focuses found in `.agent/focus/`: `problems`, `risks`, `solutions`
+- `<input-description>`: Topic or context to analyze
+- `[--roles]`: Optional comma-separated list of stakeholder perspectives
+  - Available roles found in `.agent/roles/`: `developer`, `architect`, `tester`, `user`, `product-owner`, etc.
+
+**Purpose**: Identify and analyze contexts based on specific focus areas with role-based expertise integration. Performs industry research and generates comprehensive reports.
+
+**Why Use**: To gain structured insights into problems, identify risks, or evaluate solution options with multiple stakeholder perspectives.
+
+**When to Use**:
+- **Level 0**: Use with `problems` or `risks` focus for vision clarity
+- **Level 1**: Use with `solutions` focus for approach viability
+
+**Example**:
+```bash
+/analyze problems "User authentication system showing performance degradation under load"
+/analyze risks "Migrating monolithic application to microservices architecture"
+/analyze solutions "Implementing real-time collaboration features" --roles=developer,architect,user
+```
+
+---
+
+## Context Management Commands
+
+### /sync-context
+
+**Command**: `/sync-context <any-file>` or `/sync-context init`
+
+**Arguments**:
+- `<any-file>`: Path to any file containing information to integrate
+- `init`: Special argument to initialize project context from templates
+
+**Purpose**: Extract and intelligently integrate critical information from any file into the project's core context files, maintaining context integrity across all development phases.
+
+**Why Use**: To preserve important information, decisions, and insights without manual copying, ensuring nothing is lost during phase transitions.
+
+**When to Use**:
+- **All Levels**: After any significant analysis, decision, or discovery
+- **Project Start**: Use `init` to set up context structure from templates
+
+**Example**:
+```bash
+/sync-context init
+/sync-context docs/reports/risks-security-20241215-143022.md
+/sync-context meeting-notes.txt
+```
+
+### /sync-decision
+
+**Command**: `/sync-decision <context-file> <decision-report> <selected-option>`
+
+**Arguments**:
+- `<context-file>`: Target context file (usually `context/project/decisions-made.md`)
+- `<decision-report>`: Report file containing the analysis and options
+- `<selected-option>`: The option number or identifier selected by the user
+
+**Purpose**: Formally integrate a selected decision from an analysis report into the project's decision history with full traceability and rationale.
+
+**Why Use**: To maintain a clear decision audit trail with context, alternatives considered, and rationale for future reference.
+
+**When to Use**:
+- **Level 1+**: After analyzing options and selecting an approach
+- **Any Level**: When making consequential project decisions
+
+**Example**:
+```bash
+/sync-decision context/project/decisions-made.md docs/reports/solutions-auth-20241215-150000.md 2
+/sync-decision context/project/decisions-made.md analysis-report.md "Option A"
+```
+
+### /prime-context
+
+**Command**: `/prime-context`
+
+**Arguments**: None
+
+**Purpose**: Update CLAUDE.md with a concise summary of current project context from the four context files, enabling immediate AI orientation without requiring separate context review.
+
+**Why Use**: To quickly restore working context for AI assistants after breaks or when starting new sessions, ensuring continuity and reducing repeated discovery.
+
+**When to Use**:
+- **All Levels**: At the start of new AI sessions
+- After significant context updates
+- When returning to work after breaks
+- As part of context recovery workflow
+
+**Example**:
+```bash
+/prime-context
+```
+
+---
+
+## Decomposition Commands
+
+### /decompose
+
+**Command**: `/decompose <type-definition-file> <context-file>`
+
+**Arguments**:
+- `<type-definition-file>`: Path to decomposition type definition
+  - Available types in `.agent/layers/`:
+    - `project.md` - High-level project breakdown
+    - `component.md` - System component analysis
+    - `feature.md` - Feature-level decomposition
+    - `todo.md` - Atomic task decomposition
+- `<context-file>`: Source context to decompose (project context, component spec, etc.)
+
+**Purpose**: Execute type-specific decomposition using configurable definitions, breaking down complex contexts into manageable pieces based on the selected type.
+
+**Why Use**: To systematically break down large problems into smaller, actionable pieces while maintaining relationships and dependencies.
+
+**When to Use**:
+- **Level 2+**: Progressive decomposition phases
+- Use `project.md` for initial breakdown
+- Use `component.md` for system design
+- Use `feature.md` for feature planning
+- Use `todo.md` for task-level breakdown
+
+**Example**:
+```bash
+/decompose .agent/layers/project.md context/project-context.md
+/decompose .agent/layers/component.md context/components/auth-service.md
+/decompose .agent/layers/feature.md context/features/user-registration.md
+/decompose .agent/layers/todo.md context/todos/implement-jwt-tokens.md
+```
+
+---
+
+## Planning Commands
+
+### /plan-next-steps
+
+**Command**: `/plan-next-steps <current-phase> [context-file]`
+
+**Arguments**:
+- `<current-phase>`: Description of the current project phase or state
+- `[context-file]`: Optional path to specific context file (defaults to main project context)
+
+**Purpose**: Generate detailed transition plans with prioritized actions, resource estimates, and risk mitigation strategies for moving to the next phase.
+
+**Why Use**: To create clear, actionable plans when transitioning between phases or when unsure about next steps.
+
+**When to Use**:
+- **All Levels**: At phase transitions
+- When context is recovered after interruption
+- When planning major transitions
+
+**Example**:
+```bash
+/plan-next-steps "Completed initial problem analysis"
+/plan-next-steps "Finished component design" context/components/payment-service.md
+/plan-next-steps "Ready for implementation phase"
+```
+
+---
+
+## TODO Workflow Commands
+
+### /create-todo
+
+**Command**: `/create-todo <todo-description>`
+
+**Arguments**:
+- `<todo-description>`: Clear description of the task or work item
+
+**Purpose**: Transform a TODO description into a structured context suitable for SAID integration, with clear boundaries and success criteria.
+
+**Why Use**: To capture newly discovered work items in a structured format that can be properly decomposed or executed.
+
+**When to Use**:
+- **Level 3+**: When discovering new work during decomposition
+- When identifying tasks that need structured planning
+
+**Example**:
+```bash
+/create-todo "Implement rate limiting for API endpoints"
+/create-todo "Add comprehensive error handling to payment processing"
+/create-todo "Create integration tests for user authentication flow"
+```
+
+### /create-todo-from-report
+
+**Command**: `/create-todo-from-report <report-file>`
+
+**Arguments**:
+- `<report-file>`: Path to analysis report containing options or recommendations
+
+**Purpose**: Extract actionable options from analysis reports, facilitate user selection, and generate focused TODO contexts for chosen items.
+
+**Why Use**: To convert analysis recommendations into actionable work items with user input on priorities.
+
+**When to Use**:
+- **Level 1+**: After generating analysis reports with options
+- When reports contain multiple possible actions
+
+**Example**:
+```bash
+/create-todo-from-report docs/reports/solutions-caching-20241215-160000.md
+/create-todo-from-report docs/reports/risks-security-20241215-143022.md
+```
+
+### /work-on-todo
+
+**Command**: `/work-on-todo <todo-context-file> [--expert=<expert-name>]`
+
+**Arguments**:
+- `<todo-context-file>`: Path to the TODO context file to execute
+- `[--expert]`: Optional expert system to use
+  - Available experts found in `.agent/experts/`: domain-specific expertise definitions
+
+**Purpose**: Execute atomic TODO items with appropriate collaboration checkpoints and expert guidance when needed.
+
+**Why Use**: To systematically work through implementation tasks with proper documentation and collaboration points.
+
+**When to Use**:
+- **Level 4**: Implementation execution phase
+- When ready to execute well-defined atomic tasks
+
+**Example**:
+```bash
+/work-on-todo context/todos/implement-jwt-tokens.md
+/work-on-todo context/todos/database-migration.md --expert=database
+/work-on-todo context/todos/setup-monitoring.md --expert=devops
+```
+
+---
+
+## Quick Reference: Command Usage by SAID Level
+
+### Level 0 (Vision Clarity)
+```bash
+/analyze problems context/project-context.md
+/analyze risks docs/reports/problems-*.md
+/sync-context docs/reports/problems-*.md
+/sync-context docs/reports/risks-*.md
+```
+
+### Level 1 (Approach Viability)
+```bash
+/analyze solutions context/project-context.md --role=solutions-architect
+/sync-decision context/project/project-context.md report.md 'option 1'
+/sync-context docs/reports/solutions-*.md
+```
+
+### Level 2+ (Progressive Decomposition)
+```bash
+/decompose .agent/layers/project.md context/project-context.md
+/decompose .agent/layers/component.md context/components/service.md
+/decompose .agent/layers/feature.md context/features/feature.md
+/plan-next-steps "Completed component design"
+```
+
+### Level 3 (TODO Discovery)
+```bash
+/create-todo "New task discovered during decomposition"
+/create-todo-from-report docs/reports/analysis-report.md
+/decompose .agent/layers/todo.md context/todos/task.md
+```
+
+### Level 4 (Implementation)
+```bash
+/work-on-todo context/todos/implement-feature.md
+/work-on-todo context/todos/complex-task.md --expert=typescript
+```
+
+### Context Recovery
+```bash
+/sync-context any-file-with-important-info.md
+/prime-context
+/plan-next-steps "Current situation description"
+```
+
+### Starting New AI Session
+```bash
+/prime-context
+```

--- a/docs/SAID/getting-started/README.md
+++ b/docs/SAID/getting-started/README.md
@@ -62,11 +62,11 @@ repo-name/
 The SAID methodology is implemented through task-focused commands that replace the traditional level structure:
 
 #### Vision & Problem Validation
-- `/validate-problem` - Establish clear project purpose and validate the problem space
-- `/analyze-risks` - Identify and prioritize technical and project risks
+- `/analyze problems` - Establish clear project purpose and validate the problem space
+- `/analyze risks` - Identify and prioritize technical and project risks
 
 #### Solution Development
-- `/analyze-options` - Generate and evaluate technical approach alternatives
+- `/analyze solutions` - Generate and evaluate technical approach alternatives
 - `/sync-decision` - Document chosen approach with rationale
 - `/decompose` - Break down work into manageable components at any level:
   - `.agent/layers/project.md` - System-level decomposition
@@ -98,14 +98,14 @@ For better examples, see [Git Workflow with SAID](/docs/SAID/philosophy/implemen
 
 **Vision Validation Workflow**:
 ```bash
-/validate-problem context/project-context.md
+/analyze problems context/project-context.md
 /sync-context docs/report/problem-validation.md
 /plan-next-steps context/project-context.md
 ```
 
 **Prototype Workflow**:
 ```bash
-/analyze-risks context/project-context.md
+/analyze risks context/project-context.md
 /create-todo docs/reports/risk-assessment.md 'risk 1'
 /decompose .agent/layers/todo.md context/todo/pressure-test/todo-context.md
 /work-on-todo context/todo/pressure-test/decomposed/phase-1-context.md
@@ -113,8 +113,8 @@ For better examples, see [Git Workflow with SAID](/docs/SAID/philosophy/implemen
 
 **Solution Development Workflow**:
 ```bash
-/analyze-options context/project-context.md
-/sync-decision context/project-context.md docs/reports/options-analysis.md 'option 1'
+/analyze solutions context/project-context.md
+/sync-decision context/project-context.md docs/reports/solutions-analysis.md 'option 1'
 /decompose .agent/layers/project.md context/project-context.md
 ```
 
@@ -134,10 +134,10 @@ AI: [Acknowledgment and readiness confirmation]
 
 ## Next Steps After **First Steps**
 
-1. **Start with Problem Validation**: Run `/validate-problem` to establish clear project purpose
-2. **Test Your Understanding**: Use `/pressure-test` to challenge assumptions
-3. **Identify Risks Early**: Run `/analyze-risks` to surface technical and project risks
-4. **Explore Solutions**: Use `/analyze-options` to evaluate technical approaches
+1. **Start with Problem Validation**: Run `/analyze problems` to establish clear project purpose
+2. **Test Your Understanding**: Use `/analyze risks` to challenge assumptions
+3. **Identify Risks Early**: Run `/analyze risks` to surface technical and project risks
+4. **Explore Solutions**: Use `/analyze solutions` to evaluate technical approaches
 5. **Document Decisions**: Run `/sync-decision` to capture chosen approach with rationale
 6. **Decompose Work**: Use `/decompose` with appropriate context type to break down the work
 7. **Maintain Context**: Run `/sync-context` after each significant workflow

--- a/docs/SAID/philosophy/core-concepts.md
+++ b/docs/SAID/philosophy/core-concepts.md
@@ -6,11 +6,13 @@ _The foundational thinking behind Spiral AI Development_
 
 ## The Collaboration Paradox
 
-AI excels at generating quick small solutions for well understood domains. The current AI collaboration loop therefore relies on the user breaking the problem down and clearly defining it before starting. If you don't then you get a quick small solution for a complex problem, which doesn't work as you expect.
+AI excels at generating quick small solutions for well understood domains. The current AI collaboration loop therefore relies on the user breaking the problem down and clearly defining it before starting.  If you don't then the solution will be quick, but will miss nuances of the complex problem.
 
 **The structural trap**: AI can offer answers that look complete. When working on complex problems, this creates a false confidence—you get something that sounds right but hasn't been tested against the real constraints and complexities of your domain.
 
 **Why this matters**: The more complex your problem, the more likely AI is to miss critical details, make wrong assumptions, or optimize for the wrong constraints. But the output will still sound confident and complete.
+
+Which leaves you with the question: how do you find then fix these mistakes after the fact? SAID asks: how can we identify and resolve these nuances before implementation?
 
 ---
 
@@ -24,10 +26,10 @@ Clear boundaries prevent collaboration breakdown when problems get complex.
 - Domain-specific knowledge and constraints
 - When to trust AI suggestions vs. when to override
 
-### AI Execution
+### AI Assistant
+- Research and analysis using defined roles
 - Implementation and pattern recognition
 - Systematic application of established approaches
-- Option generation and code synthesis
 - Following clear specifications
 
 ### Shared Territory
@@ -36,7 +38,7 @@ Clear boundaries prevent collaboration breakdown when problems get complex.
 - Assumption validation and clarification
 
 ### Failure Mode
-When AI starts making architectural decisions or humans start micromanaging syntax. Both indicate boundary drift that needs correction.
+When AI starts making unqualified architectural decisions or humans start micromanaging syntax. Both indicate boundary drift that needs correction.
 
 **Principle**: Decision ownership must be explicit and documented for every significant choice.
 
@@ -52,9 +54,11 @@ The greatest power and enemy of AI is its context. Working on a complex problem 
 - Rich context enables better suggestions and fewer misunderstandings
 
 ### Why Context Is Enemy
-- Context can degrade or get lost between sessions
-- Wrong context can mislead AI down incorrect paths
-- Context overload can reduce focus on current priorities
+- There are four terms currently used to describe the problems of context: Poisoning, Distraction, Confusion, and Clash.
+- **Poisoning:** if the context contains hallucinations or errors they will get repeated.
+- **Distraction:** if there is too much then the model cannot think of anything else.
+- **Confusion:** if there are too many options/tools/info the AI has a hard time of distinguishing which is currently important.
+- **Clash:** if new information contradicts existing information then the AI doesn't know which to use.
 
 ### Building Context Effectively
 - Document key decisions and their rationale

--- a/docs/SAID/philosophy/implementation-guide.md
+++ b/docs/SAID/philosophy/implementation-guide.md
@@ -1,259 +1,331 @@
 # SAID Implementation Guide
 
-_How to apply Spiral AI Development in practice_
+_Understanding the philosophy and practice of Spiral AI Development_
 
 ---
 
-## The SAID Methodology
+## The Spiral Method Philosophy
 
-Spiral development approach with progressive detail levels that handles changing requirements, timeline pressure, and context preservation.
+SAID is fundamentally about **progressive certainty through iterative deepening**. It does this by providing AI commands that ask for research, decomposition, and context integration. The user calls these commands to gather information, break the problem into smaller problems, and record decisions.
+
+### Core Principles
+
+1. **Defer Commitment Until Necessary**: Make decisions only when you have enough information to make them well
+2. **Preserve Optionality**: Keep multiple paths open until constraints force choices
+3. **Context Over Process**: Maintain rich context that survives between sessions and even team changes
+4. **Collaborative Intelligence**: Structure human-AI interaction for complementary strengths
 
 ### Progressive Detail Levels
 
+Each level represents a **threshold of understanding**, not a phase to complete:
+
 #### Level 0: Problem + Risk Clarity
-**Deliverables**: Problem validated with evidence, key risks identified with mitigation strategies, stakeholder needs documented
+**Focus**: Validate that you're solving a real problem worth solving
 
-**Workflow Pattern**:
-```bash
-/analyze-problem [input] → problem-validation-[timestamp].md
-/sync-context problem-validation-[timestamp].md
-/analyze-risks [context] → risk-assessment-[timestamp].md
-/sync-context risk-assessment-[timestamp].md
-```
+**Key Questions**:
+- What evidence supports this problem's existence?
+- Who experiences this problem and how severely?
+- What are the consequences of not solving it?
+- What could go catastrophically wrong?
 
-**Complete When**:
-- Problem statement backed by evidence of user need
-- Top 3 project risks identified with mitigation plans
-- Stakeholder perspectives documented
-- Context integrates problem validation and risk insights
+**You're Ready for Level 1 When**:
+- The problem is validated with evidence
+- Key risks are identified with mitigation strategies
+- Stakeholder needs are documented and understood
+- You can explain why this problem matters in one sentence
 
-#### Level 1: Approach Decision
-**Deliverables**: 2-3 viable approaches analyzed, decision made with documented rationale, technical feasibility validated
+#### Level 1: Approach Viability
+**Focus**: Choose a technical direction that balances constraints
 
-**Workflow Pattern**:
-```bash
-/analyze-options [context] → options-analysis-[timestamp].md
-[human review and decision]
-/sync-decision [context] [options-report] [chosen-option]
-/sync-context [updated-context]
-```
+**Key Questions**:
+- What are the fundamental ways to solve this problem?
+- What constraints (technical, resource, timeline) shape our options?
+- Which approach best fits our specific context?
+- What are we explicitly choosing NOT to do?
 
-**Complete When**:
-- Multiple viable approaches evaluated with pros/cons
-- Technical feasibility validated for chosen approach
-- Decision rationale documented with alternatives considered
-- Context reflects chosen approach and reasoning
+**You're Ready for Level 2 When**:
+- Multiple viable approaches have been evaluated
+- A direction is chosen with documented rationale
+- Trade-offs are explicit and accepted
+- Technical feasibility is validated
 
 #### Level 2: Structure Definition
-**Deliverables**: System boundaries defined, component interfaces specified
-**Workflow**: `/decompose .agent/layers/project.md [parent-context]`
+**Focus**: Define system boundaries and component relationships
+
+**Key Questions**:
+- What are the natural boundaries in this system?
+- How do components communicate and depend on each other?
+- What interfaces enable future flexibility?
+- Where are the integration points with existing systems?
+
+**You're Ready for Level 3 When**:
+- System boundaries are clearly defined
+- Component interfaces are specified
+- Dependencies are mapped and manageable
+- Integration strategy is validated
 
 #### Level 3: Implementation Specifics
-**Deliverables**: Buildable specifications, detailed component designs
-**Workflow**: `/decompose .agent/layers/component.md [parent-context]`
+**Focus**: Create buildable specifications with enough detail for execution
+
+**Key Questions**:
+- What are the implementation patterns for each component?
+- How do we handle edge cases and error conditions?
+- What testing strategy validates our assumptions?
+- Where might hidden complexity emerge?
+
+**You're Ready for Level 4 When**:
+- Specifications are detailed enough to build from
+- Testing approach is defined
+- Implementation risks are identified
+- Team has clarity on technical approach
 
 #### Level 4: Working Implementation
-**Deliverables**: Production-ready code, tested features
-**Workflow**: `/decompose .agent/layers/feature.md [parent-context]`
+**Focus**: Transform specifications into production-ready code
 
-### Spiral Navigation Rules
+**Key Activities**:
+- Write code that matches specifications
+- Implement comprehensive testing
+- Handle discovered edge cases
+- Maintain context for future developers
 
-- **Advance when**: Critical unknowns resolved for current level
-- **Defer when**: Decisions can be explicitly documented for later
-- **Navigate backward when**: Discoveries invalidate earlier assumptions
-- **Always**: Maintain context integrity across transitions
+### The Spiral Navigation Philosophy
 
-### Prototype Phase (When Risk Is Discovered)
+The spiral method isn't linear - it's **adaptive navigation through uncertainty**:
 
-**Purpose**: Validate highest-risk technical assumptions when they're identified. May occur before Level 0, during Level 1 investigation, or whenever core risks surface.
+#### Moving Forward
+Advance to the next level when you've **resolved the critical unknowns** of your current level. This isn't about completing all possible work, but about having enough clarity to make the next set of decisions well.
 
-**Activities**:
-- Identify 3 highest technical risks
-- Build throwaway prototypes to test feasibility
-- Validate integration points with real systems
-- Document discovered complexities
+#### Strategic Deferral
+Some decisions can and should be **explicitly deferred**. Document what you're deferring and why. This isn't procrastination - it's preserving flexibility until you have better information.
 
-**Success Gate**: Core technical approach proven viable
-**Failure Response**: Pivot approach or abort before sunk cost
+#### Navigating Backward
+When new discoveries **invalidate earlier assumptions**, loop back. This isn't failure - it's the spiral method working correctly. Each loop adds understanding even when it changes direction.
+
+#### Context as Navigation Aid
+Your context files are your **map through the spiral**. They record not just decisions but the reasoning, alternatives considered, and assumptions made. When you get lost, context shows you where you've been and why.
+
+### The Prototype Spike Pattern
+
+Sometimes you discover a risk that **threatens the entire approach**. The prototype spike is an escape valve - a focused effort to validate or invalidate a critical assumption before investing further.
+
+**When to Spike**:
+- A technical approach seems theoretically sound but practically uncertain
+- Integration with external systems has unknown complexity
+- Performance characteristics could invalidate the design
+- A core assumption feels shaky but is hard to validate without code
+
+**Spike Principles**:
+- Time-boxed exploration (hours to days, not weeks)
+- Throwaway code focused on learning
+   - This is important
+   - The code will rarely be built against all the context
+   - AI makes this an easy decision
+- Document what you learn, not what you build
+- Exit with either confidence or a new direction
+
+**The Spike Decision**:
+After a spike, you face three options:
+1. **Proceed**: Risk validated as manageable
+2. **Pivot**: Change approach based on learning
+3. **Abort**: Problem not solvable within constraints
 
 ---
 
-## Context Preservation
+## Context Preservation Philosophy
 
-### Context Requirements
-```yaml
-context_manifest:
-  critical_requirements: [documented and traced]
-  key_decisions: [with rationale and alternatives]
-  discovered_constraints: [impact assessment included]
-  semantic_checksum: [core purpose + users + metrics + constraints]
-```
+Context is the **persistent memory of your project's journey**. It's not documentation for documentation's sake - it's the difference between repeating mistakes and building on learned wisdom.
+
+### Why Context Matters
+
+**For Humans**: Context provides the "why" behind decisions when you return to code months later. It captures the alternatives you considered and rejected, preventing costly revisiting of dead ends.
+
+**For AI Collaboration**: Rich context enables AI to provide relevant, nuanced assistance instead of generic suggestions. The AI becomes a knowledgeable team member rather than a blank slate.
+
+**For Teams**: Context preservation enables true knowledge transfer. New team members can understand not just what was built, but why it was built that way.
+
+### The Three-File System
+
+SAID uses three primary context files that work together:
+
+1. **project-context.md**: The living manifest of current understanding
+   - Current state and phase
+   - Active constraints and requirements
+   - Integration points for all context
+
+2. **decisions-made.md**: The audit trail of choices
+   - What was decided and when
+   - Alternatives considered
+   - Rationale and trade-offs
+   - Links to supporting analysis
+
+3. **open-questions.md**: The uncertainty tracker
+   - Questions that need answers
+   - Blocked decisions awaiting information
+   - Areas requiring deeper investigation
 
 ### Context Priming Pattern
-Brief context orientation before SAID command execution ensures state continuity across sessions.
 
-**When to Use**:
-- Resuming after time gaps
-- Post-discovery work
-- Phase transitions
-- When significant context has changed
+When working with AI after any time gap, **prime the context** to restore shared understanding:
 
-**How to Use**:
 ```
-> Be aware, I've [completed work]. [Current state]. I'm about to [intended action].
-AI: [Acknowledgment and readiness confirmation]
-> /decompose .agent/layers/project.md context/approach-context.md
+"I've completed the risk analysis phase. We identified three critical risks and chose a microservices approach. I'm about to start the system decomposition."
 ```
+
+This pattern:
+- Orients the AI to current state
+- Highlights recent decisions
+- Sets clear intent for next actions
+- Takes seconds but saves hours of misdirection
+
+Additionally the `/prime-context` allows for repeating this regularly and consistently.
 
 ---
 
-## Common Workflow Patterns
+## Working with SAID: Practical Patterns
 
-### Complete Level 0 (Problem + Risk Clarity)
-```bash
-# Problem analysis
-/analyze-problem "[your problem description]"
-/sync-context docs/reports/problem-validation-[topic]-[timestamp].md
+### The Investigation-Decision-Integration Pattern
 
-# Risk assessment
-/analyze-risks context/project-context.md
-/sync-context docs/reports/risk-assessment-[topic]-[timestamp].md
+SAID workflows follow a natural rhythm:
 
-# Verify completion
-# Can you explain the core problem in one sentence?
-# Are the top 3 risks identified with mitigation plans?
-```
+1. **Investigate** - Gather information and analyze options
+2. **Decide** - Make explicit choices with human judgment
+3. **Integrate** - Preserve decisions and learning in context
 
-### Complete Level 1 (Approach Decision)
-```bash
-# Options analysis using integrated context
-/analyze-options context/project-context.md
-# [Human review of options-analysis-[timestamp].md]
+This pattern repeats at every level, creating a **ratchet effect** where progress is preserved even under pressure.
 
-# Decision integration
-/sync-decision context/project-context.md docs/reports/options-analysis-[topic]-[timestamp].md "[chosen option]"
-/sync-context context/project-context.md
+### Starting a New Project
 
-# Verify completion
-# Do you have a chosen technical approach with documented rationale?
-# Are alternative approaches preserved for future reference?
-```
+When beginning with SAID:
 
-### Context Recovery (when context is lost)
-```bash
-/sync-context current-phase context/project-context.md
-/plan-next-steps current-phase context/project-context.md
-```
+1. **Create Initial Vision** (not commands, human work)
+   - Write a brief problem statement
+   - Identify key stakeholders
+   - Define success criteria
 
-### Starting New Layer
-```bash
-# Context priming first
-> Be aware, I've completed approach validation. The technical approach is validated. I'm about to start structure definition.
-> /decompose .agent/layers/project.md context/project-context.md
-```
+2. **Initialize Context Structure**
+   - Set up the four-file system
+   - Prime with initial vision
+   - Ready for Level 0 investigation
 
----
+3. **Begin the Spiral**
+   - Start with problem validation
+   - Surface risks early
+   - Let discoveries guide the path
 
-## Troubleshooting
+### Recovering from Interruption
 
-### When Context Gets Lost
-1. Run `/sync-context` with last known good context
-2. Review context files to reconstruct decisions
-3. Use git history to trace requirement changes
-4. Regenerate context from artifact discovery
+Projects get interrupted. SAID's context preservation makes recovery straightforward:
 
-### When AI Suggestions Don't Fit
-1. Verify context includes relevant constraints
-2. Ask AI to explain assumptions behind suggestions
-3. Consider if you're in wrong spiral level for the decision
+1. **Read Your Context** - Start with project-context.md
+2. **Review Recent Decisions** - Check decisions-made.md for latest choices
+3. **Check Open Questions** - See what was pending in open-questions.md
+4. **Prime and Continue** - Brief the AI and resume where you left off
 
-### When Timeline Pressure Mounts
-1. Activate appropriate pressure protocol
-2. Document what's being deferred
-3. Maintain context preservation above all else
-4. Communicate trade-offs clearly to stakeholders
+### Handling Discoveries
+
+When you discover something that changes your understanding:
+
+1. **Document the Discovery** - What did you learn?
+2. **Assess Impact** - Does this invalidate previous decisions?
+3. **Navigate Accordingly** - Loop back if needed or adjust path forward
+4. **Update Context** - Ensure learning is preserved
+
+### The Pressure Valve Pattern
+
+When timeline pressure mounts, SAID provides structured degradation:
+
+**Moderate Pressure**: Combine investigation steps but maintain decision documentation
+**High Pressure**: Jump to implementation but preserve critical context
+**Extreme Pressure**: Emergency mode - build minimum viable, document debt for recovery
+
+The key: **Always preserve enough context to recover** when pressure subsides.
 
 ---
 
-## Pressure Adaptation Guidelines
+## Common Challenges and Solutions
 
-### Timeline Pressure
+### "The AI Keeps Suggesting Things We Already Rejected"
 
-The concepts of _Moderate_, _High_, and _Extreme_ are subjective. They are provided here to illustrate common adaptions.
+**Root Cause**: Incomplete context about previous decisions
 
-**Moderate Pressure**:
-- Combine levels where safe
-- Use proven patterns instead of custom solutions
-- Maintain context preservation
+**Solution**:
+- Ensure decisions-made.md captures rejected alternatives
+- Use context priming to remind AI of key decisions
+- Reference specific decision rationale when it matters
 
-**High Pressure**:
-- Skip to Level 3 using context priming instead of context files
-- Follow the remaining processes
-- Maintain context preservation of what you can
+### "We Keep Revisiting the Same Questions"
 
-**Extreme Pressure**:
-- Emergency mode with damage control
-- Focus only on critical functionality
+**Root Cause**: Decisions made without sufficient investigation
 
-**Recovery**:
-- When the pressure is over
-- Recover context using `/sync-context` when pressure subsides
-- Use `/create-todo` to find cleanup tasks that need to occur
+**Solution**:
+- Loop back to appropriate level for deeper investigation
+- Document why the question keeps arising
+- Consider if there's a hidden constraint not yet surfaced
 
----
+### "The Spiral Feels Too Slow"
 
-## Git Workflow with SAID
+**Root Cause**: Trying to achieve perfection at each level
 
-Use descriptive branch names that help your team understand what's happening:
+**Solution**:
+- Focus on resolving critical unknowns, not all unknowns
+- Use strategic deferral for non-critical decisions
+- Remember: the spiral prevents rework, which is slower than investigation
 
-```
-feature/user-authentication
-prototype/test-oauth-approach
-level-1/technical-feasibility
-fix/broken-login-redirect
-```
+### "Context Files Are Getting Unwieldy"
 
-**Protect your main branch** - require PRs for integration. Here's the GitHub Flow guide if you need a refresher.
+**Root Cause**: Accumulating without organizing
 
-**Consider matching code review depth to system complexity** - simple systems need basic review, complex systems need domain experts, critical systems need multiple expert reviewers. Teams might want a lightweight PR checklist to prompt thinking about tests, documentation, and context preservation.
-
-**Preserve context in git**:
-
-- Use meaningful commit messages that explain decisions
-- Keep your SAID context files in the repository
-- Reference important discussions in PR descriptions
-
-That's it. Your existing git knowledge + descriptive naming + context preservation.
+**Solution**:
+- Periodically consolidate related decisions
+- Archive completed phases while keeping references
+- Focus on active context, not historical record
 
 ---
 
-## TODO Workflow Integration
+## Integration with Development Practices
 
-**Core Principle**: Use structured TODO commands for complex work while allowing direct execution for simple tasks.
+### Git and Version Control
 
-### When to Use Full TODO Workflow
+SAID context files are **first-class citizens** in your repository:
 
-**Use structured commands for complex TODOs**:
-- Multiple steps or decisions required
-- Research with unclear approach
-- Cross-cutting concerns affecting multiple SAID workflows
-- Stakeholder input needed at decision points
+- Check in context files alongside code
+- Version control preserves decision history
+- Pull requests can include context updates
+- Branch names can reflect spiral level:
+  - `investigation/payment-options`
+  - `prototype/test-stripe-integration`
+  - `implementation/user-authentication`
 
-**Execute directly for simple TODOs**:
-- Single actions (fix typo, add comment)
-- Well-defined implementation with clear approach
-- Routine maintenance following established patterns
+### Code Review Through SAID Lens
 
-### TODO Commands
+When reviewing code with SAID context:
 
-```bash
-/create-todo                         # Create context for newly discovered TODOs
-/decompose .agent/layers/todo.md     # Break complex TODOs into atomic tasks
-/work-on-todo                        # Execute TODO with collaboration checkpoints
-/sync-context                        # Integrate results back into SAID contexts
-```
+- **Check alignment**: Does implementation match documented decisions?
+- **Question deviations**: If code differs from plan, is there a good reason?
+- **Preserve learning**: Discoveries during implementation should update context
+- **Review depth**: Match review thoroughness to documented risk level
 
-### Flexible Application
+### Testing Strategy Alignment
 
-**You don't need strict step-by-step adherence**. The workflow provides structure when complexity warrants it, but simple TODOs can bypass formal commands entirely. The goal is maintaining SAID's collaborative benefits and context integrity for work that benefits from structure, while avoiding overhead for straightforward tasks.
+SAID's risk identification (Level 0) and approach decisions (Level 1) should **directly inform** your testing strategy:
+
+- High-risk areas need comprehensive testing
+- Deferred decisions need tests that allow flexibility
+- Prototype code might skip tests but document why
+- Integration points identified in Level 2 become integration test targets
+
+---
+
+## Closing Thoughts
+
+SAID isn't a rigid process - it's a **philosophy of thoughtful progress** through uncertainty. The commands and structure support this philosophy, but the core is:
+
+1. **Make uncertainty explicit** rather than hiding it
+2. **Preserve context** for future humans and AI
+3. **Navigate adaptively** based on what you discover
+4. **Collaborate effectively** with both humans and AI
+
+The spiral method acknowledges that software development is a journey of discovery. SAID provides the tools to make that journey more predictable, recoverable, and ultimately successful.
+
+For specific command usage and syntax, refer to the [HOW-TO Guide](../getting-started/HOW-TO.md). For the underlying principles and theory, see the [SAID Philosophy](philosophy.md).
 

--- a/docs/SAID/philosophy/version.md
+++ b/docs/SAID/philosophy/version.md
@@ -1,6 +1,6 @@
 # SAID Philosophy Version
 
-**Current Version**: 2.1.1
+**Current Version**: 2.1.2
 **Development Status**: Experimental (Started 2025-07-01)
 **Next Review**: After broader validation and feedback
 
@@ -20,3 +20,4 @@ Note: These revisions represent design evolution during 4-day development proces
 - **v2.0.0**: Universal decomposition command consolidation and format modernization - [`v2.0.0-rationale-command-consolidation.md`](../revision-rationale/v2.0.0-rationale-command-consolidation.md)
 - **v2.1.0**: Pattern library refactoring - commands transformed from bureaucratic processes to adaptive behaviors - [`v2.1.0-pattern-library-refactoring.md`](../revision-rationale/v2.1.0-pattern-library-refactoring.md)
 - **v2.1.1**: Command tightening - consolidated analysis commands and restructured pattern library for reduced cognitive load - [`v2.1.1-command-tightening.md`](../revision-rationale/v2.1.1-command-tightening.md)
+- **v2.1.2**: Documentation alignment - fixed command references and added missing `/prime-context` definition - [`v2.1.2-revision-rationale.md`](../revision-rationale/v2.1.2-revision-rationale.md)

--- a/docs/SAID/revision-rationale/v2.1.1-command-tightening.md
+++ b/docs/SAID/revision-rationale/v2.1.1-command-tightening.md
@@ -13,6 +13,8 @@
 
 **User Impact**: Commands required too much mental overhead to understand which pattern to use when, leading to analysis paralysis and inconsistent application of the methodology.
 
+**Critical Missing Context**: AI-generated revisions in v2.0.0 and v2.1.0 over-indexed on complexity, creating excess cruft and tech debt that the AI couldn't identify or clean up autonomously. This required extensive manual intervention to remove false claims, incorrect success stories, and accumulated technical debt that was obscuring the core methodology.
+
 ## What Changed
 
 ### Command Consolidation

--- a/docs/SAID/revision-rationale/v2.1.2-revision-rationale.md
+++ b/docs/SAID/revision-rationale/v2.1.2-revision-rationale.md
@@ -1,0 +1,89 @@
+# SAID v2.1.2 Revision Rationale: Documentation Alignment
+
+## What Broke
+
+**Core Issue**: Documentation referenced outdated command patterns that no longer existed, causing confusion about which commands were available.
+
+**Specific Problems in v2.1.1**:
+- Role definitions referenced obsolete `/analyze-options` and `/analyze-risks` commands instead of unified `/analyze`
+- Template files still showed old command patterns in technology decision examples
+- Missing `/prime-context` command definition despite being referenced in main documentation
+- Simple typo ("Gaol" instead of "Goal") in solutions focus definition
+- Inconsistent whitespace formatting in role README
+
+**User Impact**: Users following documentation examples would encounter command not found errors, breaking their workflow and undermining confidence in the methodology.
+
+## What Changed
+
+### Command Reference Consolidation
+- Updated `.agent/roles/README.md` to reference the correct `/analyze` command with focus parameters
+- Fixed examples to show proper syntax: `/analyze solutions "..." --roles=...` instead of deprecated patterns
+- Corrected `.agent/templates/project-context-init.md` to use `/analyze solutions` in technology decision placeholders
+
+**Why**: Command consolidation happened in v2.1.1 but documentation wasn't fully updated, creating a disconnect between implementation and guidance.
+
+### Missing Command Definition Added
+- Added complete `/prime-context` command definition in `.claude/commands/prime-context.md`
+- Included full process documentation with context extraction, summary generation, and CLAUDE.md updating
+- Provided proper template structure and quality standards
+
+**Why**: The command was implemented and referenced but lacked formal definition, making it unclear how to use effectively.
+
+### Documentation Quality Improvements
+- Fixed typo in `.agent/focus/solutions.md` (Gaol → Goal)
+- Corrected whitespace formatting inconsistencies
+- Updated main CLAUDE.md to reflect current command structure and remove outdated workflow examples
+
+**Why**: Small errors accumulate to create impression of incomplete or untested methodology.
+
+## Evidence It Works
+
+**Before**:
+```bash
+/analyze-options "Mobile app backend" --roles=architect,developer
+# Command not found error
+```
+
+**After**:
+```bash
+/analyze solutions "Mobile app backend" --roles=architect,developer
+# Works as documented
+```
+
+**Key Success**: All documentation examples now match implemented command structure, eliminating the command-not-found experience that broke user trust.
+
+## What Could Go Wrong
+
+- **Risk**: Users with bookmarked old documentation pages might still reference outdated patterns → **Mitigation**: Clear migration path in getting-started guide shows correct syntax
+- **Risk**: Command definitions might drift from implementation again → **Mitigation**: Documentation alignment is now part of revision process checklist
+
+## Bottom Line
+
+This revision eliminates the disconnect between documentation and implementation that was undermining user confidence. All examples now work as documented, and the missing `/prime-context` definition provides clarity on a key workflow command.
+
+---
+
+**Date**: 2025-01-03
+**Focus**: Documentation-implementation alignment and user experience consistency
+
+---
+
+## Template Usage
+
+**Use this template for**:
+- Systematic methodology problems
+- Fundamental approach changes
+- Missing workflow pieces
+- User experience failures
+
+**Skip for**:
+- Typo fixes
+- Single command additions
+- Documentation clarification
+- Cosmetic changes
+
+**Key principles**:
+- Problem first, solution second
+- Concrete examples, not abstract descriptions
+- Honest about risks and limitations
+- Focus on user impact


### PR DESCRIPTION
Fix command references throughout documentation and add missing /prime-context definition:

- Update .agent/roles/README.md to reference correct /analyze command syntax
- Fix .agent/templates/project-context-init.md to use /analyze solutions
- Add complete /prime-context command definition in .claude/commands/
- Correct typo in .agent/focus/solutions.md (Gaol → Goal)
- Update CLAUDE.md with streamlined command reference
- Add comprehensive HOW-TO guide for all SAID commands
- Update README.md with enhanced philosophy description
- Version bump and revision rationale documentation

All documentation examples now match implemented command structure.

🤖 Generated with [Claude Code](https://claude.ai/code)